### PR TITLE
Need to add a config flag to allow html in the markup document

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,9 @@ pygmentsUseClasses = true
 pygmentsCodefencesGuessSyntax = true
 pygmentsUseClassic = false
 
+[markup.goldmark.renderer]
+unsafe = true
+
 [params]
   google_analytics_id="UA-146151202-1"
 


### PR DESCRIPTION
hugo update required a flag to compile html in a markdown file.