### PR TITLE
Add collaborators to team page

### DIFF
--- a/content/team/_collaborator_template.md
+++ b/content/team/_collaborator_template.md
@@ -1,0 +1,18 @@
+---
+title: 'Your Name'
+date: 2018-11-19T10:47:58+10:00
+draft: true
+image: 'imgs/mushr-logo.svg'
+email: 'email@email.com'
+websiteurl: 'http://mushr.io'
+github: 'prl-mushr'
+twitter: '...'
+teamtype: '2'
+weight: 100
+---
+
+- [ ] Add your name
+- [ ] Change draft to false
+- [ ] Upload photo to `static/team/` (or keep it as the mushr-logo if you don't want a photo)
+- [ ] Add relevant website, email etc.
+- [ ] A short description of you

--- a/content/team/christoforos-mavrogiannis.md
+++ b/content/team/christoforos-mavrogiannis.md
@@ -8,6 +8,7 @@ email: 'cmavro@cs.washington.edu'
 websiteurl: 'https://humanafterall.ai/'
 github: 'cmavrogiannis'
 twitter: 'mavrojean'
+teamtype: '1'
 weight: 3
 ---
 

--- a/content/team/colin-summers.md
+++ b/content/team/colin-summers.md
@@ -6,6 +6,7 @@ image: 'team/csummers.jpg'
 jobtitle: 'Research and Development'
 email: 'colinxs@cs.washington.edu'
 websiteurl: 'https://colinxsummers.com/'
+teamtype: '1'
 weight: 7
 ---
 

--- a/content/team/fereshteh-sadeghi.md
+++ b/content/team/fereshteh-sadeghi.md
@@ -7,6 +7,7 @@ jobtitle: 'Postdoctoral Fellow'
 email: 'fsadeghi@cs.washington.edu'
 websiteurl: 'https://homes.cs.washington.edu/~fsadeghi/'
 twitter: 'fereshteh_sa'
+teamtype: '1'
 weight: 3
 ---
 

--- a/content/team/johan-michalove.md
+++ b/content/team/johan-michalove.md
@@ -8,6 +8,7 @@ email: 'michajoh@cs.washington.edu'
 websiteurl: 'http://johanam.com/'
 github: 'johannesburg'
 twitter: 'MichaloveJohan'
+teamtype: '1'
 weight: 4
 ---
 

--- a/content/team/matt-schmittle.md
+++ b/content/team/matt-schmittle.md
@@ -6,6 +6,7 @@ image: 'team/mschmittle.jpg'
 jobtitle: 'Project Lead'
 email: 'schmttle@cs.washington.edu'
 websiteurl: 'https://schmittlema.github.io/'
+teamtype: '1'
 weight: 3
 ---
 

--- a/content/team/matthew-rockett.md
+++ b/content/team/matthew-rockett.md
@@ -5,6 +5,7 @@ draft: false
 image: 'team/mrockett.png'
 jobtitle: 'Robot Wrangler'
 email: 'rockettm@cs.washington.edu'
+teamtype: '1'
 weight: 6
 ---
 

--- a/content/team/patrick-lancaster.md
+++ b/content/team/patrick-lancaster.md
@@ -6,6 +6,7 @@ image: 'team/plancaster.jpg'
 jobtitle: 'Hardware Lead'
 email: 'planc509@cs.washington.edu'
 websiteurl: 'https://homes.cs.washington.edu/~planc509/'
+teamtype: '1'
 weight: 5
 ---
 

--- a/content/team/sanjiban-choudhury.md
+++ b/content/team/sanjiban-choudhury.md
@@ -6,6 +6,7 @@ image: 'team/sachoudhury.png'
 jobtitle: 'Postdoctoral Fellow'
 email: 'sanjibac@cs.uw.edu'
 websiteurl: 'http://www.sanjibanchoudhury.com'
+teamtype: '1'
 weight: 2
 ---
 

--- a/content/team/sidd-srinivasa.md
+++ b/content/team/sidd-srinivasa.md
@@ -8,6 +8,7 @@ email: 'siddh@cs.washington.edu'
 twitter: siddhss5
 websiteurl: 'https://goodrobot.ai/'
 github: siddhss5
+teamtype: '1'
 weight: 1
 ---
 

--- a/themes/hugo-serif-theme/layouts/team/list.html
+++ b/themes/hugo-serif-theme/layouts/team/list.html
@@ -18,11 +18,24 @@
   </div>
 </div>
 
-<div class="container pt-6 pb-md-12">
-  <div class="row">
-    {{ range .Pages.ByWeight }}
-    <div class="col-12 col-md-6 mb-2 ">{{ .Render "summary" }}</div>
-    {{ end }}
-  </div>
+
+{{ $team_names := dict "1" "Core Team" "2" "Collaborators" }}
+
+<div class="team">
+    <div class="container">
+        <div class="container pt-6 pb-md-12">
+            {{ range .Pages.GroupByParam "Teamtype" "asc"}}
+            <h1>{{ index $team_names .Key }}</h1>
+            <div class="row">
+                {{ range .Pages.ByWeight }}
+                {{ if not .Params.Draft }}
+                <div class="col-12 col-md-6 mb-2 ">{{ .Render "summary" }}</div>
+                {{ end }}
+                {{ end }}
+            </div>
+            {{end}}
+        </div>
+    </div>
 </div>
-{{ end }}
+
+{{end}}


### PR DESCRIPTION
Added a subsection to the team page for collaborators. The format for an entry is the same as the core team. I called the two divisions "Core Team" and "Collaborators". Let me know if you think there is a better way to do this. In the markdown files, there is a new field called `teamtype` where `1` is core and `2` is collaborator. The weights still work the same.